### PR TITLE
Fix erroneous 'v' in ghcr-cleanup regex

### DIFF
--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -23,5 +23,5 @@ jobs:
               with:
                   package-name: wingtechbot-mk3/${{ matrix.package.name }}
                   package-type: container
-                  ignore-versions: ^v\d+\.\d+\.\d+$ # Keeps only packages matching this regex
+                  ignore-versions: ^\d+\.\d+\.\d+$ # Keeps only packages matching this regex
                   min-versions-to-keep: 0


### PR DESCRIPTION
Container versions can't start with a letter. Idfk why I added this 'v'.